### PR TITLE
feat: add fd global ignore file to keep fcp/fd fast in noisy dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ fcp
 # to:   <fuzzy-search dirs>
 ```
 
+Hidden files/dirs (dotfiles) are off by default in each picker — press **ctrl-h** to toggle them on, ctrl-h again to hide them.
+
 More shell functions can be added to `zsh/functions.zsh` over time — re-run `tools.sh` to pick up the symlink if it's missing, no need to touch `.zshrc` again.
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A personal Neovim config (and friends). This repo manages configs for:
 | [Lazygit](https://github.com/jesseduffield/lazygit) | `lazygit/` |
 | [Alacritty](https://alacritty.org) | `alacritty/` *(optional, see below)* |
 | zsh functions (`fcp`, ...) | `zsh/` *(optional, see [QoL Shell Tools](#qol-shell-tools))* |
+| fd global ignore rules | `fd/` *(optional, see [QoL Shell Tools](#qol-shell-tools))* |
 
 ## Quick Start
 
@@ -61,8 +62,9 @@ Any change you make in `~/.config/nvim` is a change in this repo — just `git c
 
 It will:
 1. **Install `fzf` and `fd`** — via Homebrew/apt/pacman. On Debian/Ubuntu the `fd-find` package installs its binary as `fdfind`; `tools.sh` symlinks it to `~/.local/bin/fd` so it's callable the same way everywhere.
-2. **Install [oh-my-zsh](https://ohmyz.sh/)** — non-interactively (`RUNZSH=no CHSH=no KEEP_ZSHRC=yes`), so your existing `.zshrc` is left in place.
-3. **Symlink `zsh/` → `~/.config/zsh`** and add a `source` line to `.zshrc` (backed up first, and only added once).
+2. **Symlink `fd/ignore` → `~/.config/fd/ignore`** — `fd` always reads this file (gitignore syntax) regardless of `--hidden`, so noisy dirs (`node_modules`, `.cache`, `.cargo`, build output, ...) stay out of every `fd` search, including `fcp`'s. Edit `fd/ignore` in the repo to add more.
+3. **Install [oh-my-zsh](https://ohmyz.sh/)** — non-interactively (`RUNZSH=no CHSH=no KEEP_ZSHRC=yes`), so your existing `.zshrc` is left in place.
+4. **Symlink `zsh/` → `~/.config/zsh`** and add a `source` line to `.zshrc` (backed up first, and only added once).
 
 This gives you `fcp` — a shell function that fuzzy-picks a source file and a destination directory (via `fd` + `fzf`) and copies it, so you never have to type or remember full paths:
 

--- a/fd/ignore
+++ b/fd/ignore
@@ -1,0 +1,31 @@
+# Global ignore rules for fd (https://github.com/sharkdp/fd) — gitignore syntax.
+# Applied everywhere fd runs (including via `fcp`, `zsh/functions.zsh`),
+# regardless of --hidden. Keeps searches from home/large dirs fast and readable.
+
+# VCS
+.git/
+
+# Language / package managers
+node_modules/
+.venv/
+venv/
+__pycache__/
+.cargo/
+.rustup/
+
+# Caches
+.cache/
+.npm/
+
+# Framework / build output
+dist/
+build/
+target/
+.next/
+.nuxt/
+.terraform/
+
+# Misc noisy dirs
+.oh-my-zsh/
+.vscode-server/
+.Trash/

--- a/tools.sh
+++ b/tools.sh
@@ -110,6 +110,32 @@ install_fd() {
     fi
 }
 
+# ── fd global ignore ───────────────────────────────────────────────────────────
+# fd always reads ~/.config/fd/ignore (gitignore syntax), regardless of --hidden.
+# Symlinking it keeps `fd`/`fcp` fast in noisy dirs like $HOME.
+link_fd_ignore() {
+    local src="$REPO_DIR/fd/ignore"
+    local dest="$HOME/.config/fd/ignore"
+
+    mkdir -p "$HOME/.config/fd"
+
+    if [[ -L "$dest" && "$(readlink "$dest")" == "$src" ]]; then
+        success "$dest already linked"
+        return
+    fi
+
+    if [[ -e "$dest" && ! -L "$dest" ]]; then
+        local backup="${dest}.bak.$(date +%Y%m%d%H%M%S)"
+        warn "Backing up existing $dest → $backup"
+        mv "$dest" "$backup"
+    elif [[ -L "$dest" ]]; then
+        rm "$dest"
+    fi
+
+    ln -s "$src" "$dest"
+    success "Linked $dest → $src"
+}
+
 # ── shell functions (fcp, ...) ────────────────────────────────────────────────
 link_zsh_functions() {
     local src="$REPO_DIR/zsh"
@@ -156,6 +182,7 @@ echo ""
 
 install_fzf
 install_fd
+link_fd_ignore
 install_ohmyzsh
 link_zsh_functions
 

--- a/zsh/functions.zsh
+++ b/zsh/functions.zsh
@@ -1,3 +1,24 @@
+# _fcp_pick <f|d> <prompt> — fuzzy-pick a file/dir via fd + fzf.
+# ctrl-h toggles hidden files on/off mid-search (off by default).
+# Requires: fzf, fd
+_fcp_pick() {
+    local type="$1" prompt="$2"
+    local state; state=$(mktemp)
+    echo 0 > "$state"
+
+    local show="fd --type $type"
+    local show_hidden="fd --type $type --hidden"
+    local toggle="if [ \"\$(cat $state)\" = 0 ]; then echo 1 > $state; $show_hidden; else echo 0 > $state; $show; fi"
+
+    local result
+    result=$(eval "$show" | fzf --prompt="$prompt" \
+        --header 'ctrl-h: toggle hidden files' \
+        --bind "ctrl-h:reload($toggle)")
+
+    rm -f "$state"
+    echo "$result"
+}
+
 # fcp — fuzzy-pick a file and a destination dir, then copy.
 # Requires: fzf, fd
 fcp() {
@@ -7,10 +28,10 @@ fcp() {
     fi
 
     local src dest
-    src=$(fd --type f --hidden --exclude .git | fzf --prompt="copy: ")
+    src=$(_fcp_pick f "copy: ")
     [[ -z "$src" ]] && return 1
 
-    dest=$(fd --type d --hidden --exclude .git | fzf --prompt="to: ")
+    dest=$(_fcp_pick d "to: ")
     [[ -z "$dest" ]] && return 1
 
     cp -v "$src" "$dest"


### PR DESCRIPTION
fcp's fd search uses --hidden to reach dotfiles, which also pulled in heavy dirs like node_modules, .cache, .cargo, .oh-my-zsh when run from $HOME. fd always reads ~/.config/fd/ignore (gitignore syntax) regardless of --hidden, so tools.sh now symlinks fd/ignore there instead of hardcoding excludes into fcp — keeps the exclusions in one place and benefits any future fd use, not just fcp.