### PR TITLE
feat: add fcd for fuzzy-picking a directory to cd into

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,19 @@ It will:
 3. **Install [oh-my-zsh](https://ohmyz.sh/)** — non-interactively (`RUNZSH=no CHSH=no KEEP_ZSHRC=yes`), so your existing `.zshrc` is left in place.
 4. **Symlink `zsh/` → `~/.config/zsh`** and add a `source` line to `.zshrc` (backed up first, and only added once).
 
-This gives you `fcp` — a shell function that fuzzy-picks a source file and a destination directory (via `fd` + `fzf`) and copies it, so you never have to type or remember full paths:
+This gives you two shell functions built on `fd` + `fzf`, so you never have to type or remember full paths:
 
-```bash
-fcp
-# copy: <fuzzy-search files>
-# to:   <fuzzy-search dirs>
-```
+- **`fcp`** — fuzzy-pick a source file and a destination directory, then copy:
+  ```bash
+  fcp
+  # copy: <fuzzy-search files>
+  # to:   <fuzzy-search dirs>
+  ```
+- **`fcd`** — fuzzy-pick a directory and `cd` into it:
+  ```bash
+  fcd
+  # cd: <fuzzy-search dirs>
+  ```
 
 Hidden files/dirs (dotfiles) are off by default in each picker — press **ctrl-h** to toggle them on, ctrl-h again to hide them.
 

--- a/zsh/functions.zsh
+++ b/zsh/functions.zsh
@@ -36,3 +36,18 @@ fcp() {
 
     cp -v "$src" "$dest"
 }
+
+# fcd — fuzzy-pick a directory and cd into it.
+# Requires: fzf, fd
+fcd() {
+    if ! command -v fzf &>/dev/null || ! command -v fd &>/dev/null; then
+        echo "fcd: requires fzf and fd — run tools.sh to install them" >&2
+        return 1
+    fi
+
+    local dir
+    dir=$(_fcp_pick d "cd: ")
+    [[ -z "$dir" ]] && return 1
+
+    cd "$dir"
+}


### PR DESCRIPTION
Reuses _fcp_pick (fd + fzf, ctrl-h hidden-file toggle, fd/ignore filtering) so fcd gets the same behavior as fcp's destination picker for free.